### PR TITLE
Add support for >=tsdl.0.9.0 through result type

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -10,7 +10,7 @@ Plugins:     META (0.4)
 Library "tsdl_ttf"
   Path:         src
   Modules:      Tsdl_ttf
-  BuildDepends: ctypes, tsdl
+  BuildDepends: ctypes, tsdl, result
   BuildTools:   ocamlbuild
   CCLib:        -lSDL2_ttf
   XMETAEnable:  true
@@ -19,5 +19,5 @@ Executable "show_string"
   Install:      false
   Path:         test
   BuildTools:   ocamlbuild
-  BuildDepends: tsdl, tsdl_ttf, threads
+  BuildDepends: tsdl, tsdl_ttf, threads, result
   MainIs:       show_string.ml

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1"
 name: "tsdl-ttf"
-version: "0.1"
+version: "0.2"
 maintainer: "Julian Squires <julian@cipht.net>"
 authors: ["Julian Squires <julian@cipht.net>"]
 homepage: "http://github.com/tokenrove/tsdl-ttf"
@@ -11,7 +11,8 @@ license: "BSD3"
 depends: [
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign"
-  "tsdl" {> "0.8.1"}
+  "tsdl" {>= "0.9.0"}
+  "result"
   "oasis" {build}
 ]
 build: [

--- a/src/tsdl_ttf.ml
+++ b/src/tsdl_ttf.ml
@@ -1,15 +1,16 @@
 open Ctypes
 open Foreign
 open Tsdl
+open Result
 
 module Ttf = struct
 
-type 'a result = [ `Ok of 'a | `Error of string ]
+type 'a result = 'a Sdl.result
 
-let error () = `Error (Sdl.get_error ())
+let error () = Error (`Msg (Sdl.get_error ()))
 
 let zero_to_ok =
-  let read = function 0 -> `Ok () | err -> error () in
+  let read = function 0 -> Ok () | err -> error () in
   view ~read ~write:(fun _ -> assert false) int
 
 let bool =
@@ -113,7 +114,7 @@ let glyph_metrics f g =
                                        allocate int 0)
   in
   if 0 = glyph_metrics f g min_x max_x min_y max_y advance then
-    `Ok GlyphMetrics.({ min_x = !@ min_x;
+    Ok GlyphMetrics.({ min_x = !@ min_x;
                         max_x = !@ max_x;
                         min_y = !@ min_y;
                         max_y = !@ max_y;
@@ -124,12 +125,12 @@ let glyph_metrics f g =
 let size_text = foreign "TTF_SizeText" (font @-> string @-> ptr int @-> ptr int @-> returning int)
 let size_text f s =
   let (w,h) = (allocate int 0, allocate int 0) in
-  if 0 = size_text f s w h then `Ok (!@ w, !@ h) else error ()
+  if 0 = size_text f s w h then Ok (!@ w, !@ h) else error ()
 
 let size_utf8 = foreign "TTF_SizeUTF8" (font @-> string @-> ptr int @-> ptr int @-> returning int)
 let size_utf8 f s =
   let (w,h) = (allocate int 0, allocate int 0) in
-  if 0 = size_utf8 f s w h then `Ok (!@ w, !@ h) else error ()
+  if 0 = size_utf8 f s w h then Ok (!@ w, !@ h) else error ()
 
 let size_unicode =
   foreign "TTF_SizeUNICODE" (font @-> ptr glyph_ucs2 @-> ptr int @-> ptr int @-> returning int)

--- a/src/tsdl_ttf.mli
+++ b/src/tsdl_ttf.mli
@@ -9,9 +9,7 @@ module Ttf : sig
     {{:https://www.libsdl.org/projects/SDL_ttf/docs/index.html}SDL2_ttf API}
 *)
 
-type 'a result = [ `Ok of 'a | `Error of string ]
-(** The type for function results. In the [`Error] case,
-    the string is what {!Tsdl.Sdl.get_error} returned. *)
+type 'a result = 'a Tsdl.Sdl.result
 
 val init : unit -> unit result
 val quit : unit -> unit

--- a/test/show_string.ml
+++ b/test/show_string.ml
@@ -1,9 +1,10 @@
 open Tsdl
 open Tsdl_ttf
+open Result
 
 let (>>=) o f =
-  match o with | `Error e -> failwith (Printf.sprintf "Error %s" e)
-               | `Ok a -> f a
+  match o with | Error (`Msg e) -> failwith (Printf.sprintf "Error %s" e)
+               | Ok a -> f a
 
 let unwind ~(protect:'a -> unit) f x =
   try let y = f x in protect x; y
@@ -27,11 +28,11 @@ let () =
   let rec loop () =
     Sdl.fill_rect display None 0l >>= fun () ->
     let Some sface = Ttf.render_text_solid font "foobar" fg_color in
-    Sdl.blit_surface sface None display r >>= fun () ->
+    Sdl.blit_surface sface None display ( Some r ) >>= fun () ->
     Sdl.update_window_surface window >>= fun () ->
     match Sdl.wait_event (Some e) with
-    | `Error err -> Sdl.log "Could not wait event: %s" err; ()
-    | `Ok () ->
+    | Error (`Msg err) -> Sdl.log "Could not wait event: %s" err; ()
+    | Ok () ->
       match Sdl.Event.(enum (get e typ)) with
       | `Quit | `Key_down -> ()
       | _ -> loop ()


### PR DESCRIPTION
Thanks for creating this package; it would be great to get to get this onto opam.


I'm not sure why the travis ci build is failing; no rakefile?